### PR TITLE
Add hypothesis property-based testing

### DIFF
--- a/tests/sparsemax/test_sparsemax_pb.py
+++ b/tests/sparsemax/test_sparsemax_pb.py
@@ -91,7 +91,6 @@ def test_sparsemax_backward_pb(random_data, dim):
     ),
     dim=st.integers(min_value=-1, max_value=0),
 )
-@pytest.mark.skip
 def test_sparsemax_v2_threshold_and_support(random_data, dim):
     x = torch.tensor(random_data, dtype=torch.double)
     tau, support_size = SparsemaxFunction._threshold_and_support(x, dim=dim)
@@ -112,7 +111,6 @@ def test_sparsemax_v2_threshold_and_support(random_data, dim):
         elements=st.floats(min_value=-1000, max_value=1000, allow_nan=False, allow_infinity=False),
     ),
 )
-@pytest.mark.skip
 def test_compare_with_original(random_data):
     x = torch.tensor(random_data, dtype=torch.double, requires_grad=True)
     for dim in range(-1, x.dim()):


### PR DESCRIPTION
Refactor `SparsemaxFunction` to improve modularity and add property-based testing.

* **Refactor `SparsemaxFunction`**
  - Create `_threshold_and_support` sub-function to handle threshold and support computation logic.
  - Create `_compute_gradient` sub-function to handle gradient computation logic.
  - Move reshaping logic to sub-functions and ensure `ctx` operations are done in `forward` and `backward` only.

* **Add Unit Tests**
  - Add unit tests for `_threshold_and_support` sub-function.
  - Add unit tests for `_compute_gradient` sub-function.
  - Add unit tests for reshaping logic sub-functions.

* **Add Property-Based Tests**
  - Add hypothesis property-based testing for `_threshold_and_support` sub-function.
  - Add hypothesis property-based testing for `_compute_gradient` sub-function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/DanielAvdar/activations-plus/pull/17?shareId=9332155c-fcd0-4209-b1cd-e29019055ddc).